### PR TITLE
Fix of typos

### DIFF
--- a/concurrency_theory_2017/exercises/exercises_3.md
+++ b/concurrency_theory_2017/exercises/exercises_3.md
@@ -58,7 +58,7 @@ Furthermore, `R` respects the following:
 
 Let us explain what firing a transition means in the context of extended Petri net.
 
-`t` is enabled at `M` iff `∀ p ∈ S. M(s) ≥ W(s,t)`.
+`t` is enabled at `M` iff `∀ s ∈ S. M(s) ≥ W(s,t)`.
 This is similar to Petri nets.
 
 `M [t〉 M′` is computed as follow:
@@ -67,7 +67,7 @@ This is similar to Petri nets.
 3. assume `R(t) = (s₁,s₂)` create an intermediate marking `M₂` to apply the reset/transfer:
   * if `s ≠ s₁ ∧ s ≠ s₂` then `M₂(s) = M₁(s)`
   * if `s = s₁` then `M₂(s) = 0`
-  * if `s = s₂` then `M₂(s) = M₁(s₁)`
+  * if `s = s₂` then `M₂(s) = M₁(s) + M₁(s₁)`
 4. compute the final marking: `M′(s) = M₂(s) + W(t,s)`.
 
 #### Reset net example

--- a/concurrency_theory_2017/notes_2.md
+++ b/concurrency_theory_2017/notes_2.md
@@ -80,11 +80,11 @@ The example (A) corresponds to:
 
 ### Petri Net Semantics
 
-A transition `t` in `(S,T,W)` with marking `M` is _enabled_ iff `∀ p ∈ S. M(s) ≥ W(s,t)`.
+A transition `t` in `(S,T,W)` with marking `M` is _enabled_ iff `∀ s ∈ S. M(s) ≥ W(s,t)`.
 
 If no transition is enabled at `M` then it is a _deadlock_.
 
-An enabled transition `t` can _fire_ and produce a new marking `M′`, such that, `∀ p ∈ S. M′(s) = M(s) - W(s,t) + W(t,s)`.
+An enabled transition `t` can _fire_ and produce a new marking `M′`, such that, `∀ s ∈ S. M′(s) = M(s) - W(s,t) + W(t,s)`.
 
 Transitions induce a _firing relation_ which contain triples `(M₁,t,M₂)` iff
 - `t` is enabled in `M₁` and

--- a/concurrency_theory_2017/notes_3.md
+++ b/concurrency_theory_2017/notes_3.md
@@ -301,7 +301,7 @@ TerminationCheck(S,T,W,M₀)
     while F ≠ ∅  do
         choose M in F
         F ← F ∖ {M}
-        ancestors ← { A | a can reach M in E }
+        ancestors ← { A | A can reach M in E }
         if ∃ A ∈ ancestors. A ≤ M then
             return NON-TERMINATING
         else
@@ -371,7 +371,7 @@ BoundednessCheck(S,T,W,M₀)
     while F ≠ ∅  do
         choose M in F
         F ← F ∖ {M}
-        ancestors ← { A | a can reach M in E }
+        ancestors ← { A | A can reach M in E }
         if ∃ A ∈ ancestors. A < M then
             return UNBOUNDED
         else if ∃ A ∈ ancestors. A = M then


### PR DESCRIPTION
Changed the case in definition of ancestors set (boundedness algorithm, termination algorithm).
Changed quantification in definition of transition. (quantifying over s, not over p)