### PR TITLE
fix typo

### DIFF
--- a/concurrency_theory_2019/notes/notes_2.md
+++ b/concurrency_theory_2019/notes/notes_2.md
@@ -494,7 +494,7 @@ Let look back at the "lock and increment" example from [the first week](viewer.h
       p3 -> p1 [ style = invis];
   }
   ```
-4. We can even add many more threads by adding a transition $spawn$ with: $M(spawn, 0) = 1$.
+4. We can even add many more threads by adding a transition $spawn$ with: $W(spawn, 0) = 1$.
   ```graphviz
   digraph PN {
       rankdir=LR;


### PR DESCRIPTION
This is supposed to be the weight function with 2 arguments, the marking function has only 1 argument.